### PR TITLE
Fix customBlock error display logic priority

### DIFF
--- a/script.js
+++ b/script.js
@@ -316,40 +316,38 @@ class EditorJSViewer {
         const container = document.createElement('div');
         container.className = 'custom-block';
 
-        // Handle nested block first
-        if (data.block && data.block.type) {
+        // Check for validation errors and show updated content with error styling
+        if (data.updatedChange && data.itemToFix) {
+            // This is an error case - show the updated content in red
+            const updatedContent = document.createElement('p');
+            updatedContent.innerHTML = data.updatedChange;
+            updatedContent.className = 'validation-error';
+
+            // Add validation info
+            if (data.itemToFix.description) {
+                const errorInfo = document.createElement('div');
+                errorInfo.className = 'error-info';
+                errorInfo.innerHTML = `⚠️ ${data.itemToFix.description}`;
+                container.appendChild(errorInfo);
+            }
+
+            container.appendChild(updatedContent);
+        }
+        // Show updated content without error styling if available
+        else if (data.updatedChange) {
+            const updatedContent = document.createElement('p');
+            updatedContent.innerHTML = data.updatedChange;
+            container.appendChild(updatedContent);
+        }
+        // Handle nested block if no updated content
+        else if (data.block && data.block.type) {
             const nestedBlock = this.createBlockElement(data.block);
             if (nestedBlock) {
                 container.appendChild(nestedBlock);
             }
         }
-
-        // Show the updated content if available
-        if (data.updatedChange) {
-            const updatedContent = document.createElement('p');
-            updatedContent.innerHTML = data.updatedChange;
-
-            // Check if this is an error/validation issue
-            if (data.itemToFix) {
-                updatedContent.style.color = 'red';
-                updatedContent.style.fontWeight = 'bold';
-                updatedContent.className = 'validation-error';
-
-                // Add validation info
-                if (data.itemToFix.description) {
-                    const errorInfo = document.createElement('div');
-                    errorInfo.className = 'error-info';
-                    errorInfo.style.color = '#d73502';
-                    errorInfo.style.fontSize = '0.9em';
-                    errorInfo.style.marginTop = '5px';
-                    errorInfo.innerHTML = `⚠️ ${data.itemToFix.description}`;
-                    container.appendChild(errorInfo);
-                }
-            }
-
-            container.appendChild(updatedContent);
-        } else if (data.original) {
-            // Fallback to original content
+        // Fallback to original content
+        else if (data.original) {
             const originalContent = document.createElement('p');
             originalContent.innerHTML = data.original;
             container.appendChild(originalContent);

--- a/test-error.json
+++ b/test-error.json
@@ -1,0 +1,41 @@
+{
+  "time": 1758708351099,
+  "blocks": [
+    {
+      "id": "test-header",
+      "data": {"text": "Test Error Display", "level": 1},
+      "type": "header"
+    },
+    {
+      "id": "error-test",
+      "data": {
+        "type": "customBlock",
+        "block": {
+          "id": "jobsummary_positiontype",
+          "data": {"text": "Position Type: [No information provided]"},
+          "type": "paragraph"
+        },
+        "original": "Position Type: [No information provided]",
+        "itemToFix": {
+          "id": "5de99356-c6b8-4537-8daf-85d75fc7148d",
+          "value": "Position Type:Full-Time",
+          "impact": "Medium",
+          "heading": "Add Position Type",
+          "jd_score": 3,
+          "json_key": "job_summary.position_type",
+          "description": "Specify the type of employment for clarity.",
+          "editorAction": "append",
+          "editorjs_key": "jobsummary_positiontype"
+        },
+        "updatedChange": "Position Type:Full-Time"
+      },
+      "type": "customBlock"
+    },
+    {
+      "id": "normal-paragraph",
+      "data": {"text": "This is normal text that should appear normally."},
+      "type": "paragraph"
+    }
+  ],
+  "version": "2.31.0"
+}


### PR DESCRIPTION
- Fixed logic priority where nested blocks were processed before error styling
- Now checks for updatedChange + itemToFix first to apply red error styling
- Added test file with sample error data for verification
- Error content should now properly display in red with validation messages

🤖 Generated with [Claude Code](https://claude.ai/code)